### PR TITLE
force loss/prediction passed to Lighthouse to be moved to CPU

### DIFF
--- a/src/LighthouseFlux.jl
+++ b/src/LighthouseFlux.jl
@@ -118,7 +118,7 @@ function Lighthouse.train!(classifier::FluxClassifier, batches, logger)
 end
 
 function Lighthouse.loss_and_prediction(classifier::FluxClassifier, batch...)
-    return loss_and_prediction(classifier.model, batch...)
+    return Flux.cpu(loss_and_prediction(classifier.model, batch...))
 end
 
 #####


### PR DESCRIPTION
AFAICT we might as well force this automatically if Lighthouse metrics aren't GPU-amenable anyway. Would be good for folks to test this out before we merge it, just in case.

Not really feasible to unit test this until we have GPU-enabled CI. 

