### PR TITLE
Remove nondeterminism from test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Flux = "0.10.4, 0.11, 0.12"
-Lighthouse = "0.11.3"
+Lighthouse = "0.11"
 StableRNGs = "1.0"
 Zygote = "0.4.13, 0.5, 0.6"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Flux = "0.10.4, 0.11, 0.12"
-Lighthouse = "0.11"
+Lighthouse = "0.11.3"
 StableRNGs = "1.0"
 Zygote = "0.4.13, 0.5, 0.6"
 julia = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, StableRNGs
-using LighthouseFlux, Lighthouse, Flux
+using LighthouseFlux, Lighthouse, Flux, Random
 
 # Set up plotting backend for Plots.jl (GR)
 using Lighthouse.Plots
@@ -23,6 +23,7 @@ end
         rng = StableRNG(157)
         classes = ["class_$i" for i in 1:5]
         c, n = 5, 3
+        Random.seed!(0)
         model = TestModel(Chain(Dense(4 * c, 2 * c),
                                 Dense(2 * c, c), softmax))
         # assure that `testmode!` and `trainmode!` is being utilized correctly after training


### PR DESCRIPTION
Default initialization of `Flux.Dense` layer makes use of the `Random.GLOBAL_RNG()`; seed it!