### PR TITLE
add weight and gradient logging

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,13 +48,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: julia --project=docs docs/make.jl
+          version: 1.6
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      # Get codecov for doctests
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Functors = "0.2.8"
 Lighthouse = "0.14.6"
 StableRNGs = "1.0"
 Zygote = "0.4.13, 0.5, 0.6"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,16 @@ version = "0.3.4"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 Lighthouse = "ac2c24cd-07f0-4848-96b2-1b82c3ea0e59"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 CairoMakie = "0.6.2"
 Flux = "0.10.4, 0.11, 0.12"
+Functors = "0.2.8"
 Lighthouse = "0.12, 0.13"
 StableRNGs = "1.0"
 Zygote = "0.4.13, 0.5, 0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-CairoMakie = "0.6.2"
+CairoMakie = "0.6.2, 0.7"
 Flux = "0.10.4, 0.11, 0.12"
 Functors = "0.2.8"
-Lighthouse = "0.12, 0.13"
+Lighthouse = "0.14.6"
 StableRNGs = "1.0"
 Zygote = "0.4.13, 0.5, 0.6"
 julia = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LighthouseFlux"
 uuid = "56a5d6c5-c9a8-4db3-ae3d-7c3fdb50c563"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 LighthouseFlux = "56a5d6c5-c9a8-4db3-ae3d-7c3fdb50c563"
 
 [compat]
-Documenter = "0.25"
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@ using Documenter
 
 makedocs(; modules=[LighthouseFlux], sitename="LighthouseFlux",
          authors="Beacon Biosignals and other contributors",
-         pages=["API Documentation" => "index.md"])
+         pages=["API Documentation" => "index.md"],
+         strict=true)
 
 deploydocs(; repo="github.com/beacon-biosignals/LighthouseFlux.jl.git", devbranch="main")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,3 +10,10 @@ LighthouseFlux.loss
 LighthouseFlux.loss_and_prediction
 LighthouseFlux.evaluate_chain_in_debug_mode
 ```
+
+## Internal functions
+
+```@docs
+LighthouseFlux.gather_weights_gradients
+LighthouseFlux.fforeach_pairs
+```

--- a/src/LighthouseFlux.jl
+++ b/src/LighthouseFlux.jl
@@ -2,7 +2,7 @@ module LighthouseFlux
 
 using Zygote: Zygote
 using Flux: Flux
-using Lighthouse: Lighthouse, classes, log_resource_info!, log_values!, log_arrays!
+using Lighthouse: Lighthouse, classes, log_resource_info!, log_values!, log_arrays!, step_logger!
 using Functors
 using Statistics
 
@@ -199,6 +199,7 @@ function Lighthouse.train!(classifier::FluxClassifier, batches, logger)
             return nothing
         end
         log_arrays!(logger, gather_weights_gradients(classifier, gradients))
+        step_logger!(logger)
     end
     Flux.testmode!(classifier.model)
     return nothing

--- a/src/LighthouseFlux.jl
+++ b/src/LighthouseFlux.jl
@@ -88,7 +88,10 @@ end
     fforeach_pairs(F, x, keys=(); exclude=Functors.isleaf, cache=IdDict(),
                    prune=Functors.NoKeyword(), combine=(ks, k) -> (ks..., k))
 
-Walks the Functors.jl-compatible graph `x` (by calling `pairs ∘ Functors.children`), applying `F(parent_key, child)` at each step along the way. Here `parent_key` is the `key` part of a key-value pair returned from `pairs ∘ Functors.children`, combined with the previous `parent_key` by `combine`.
+Walks the Functors.jl-compatible graph `x` (by calling `pairs ∘ Functors.children`), applying
+`F(parent_key, child)` at each step along the way. Here `parent_key` is the `key` part of a
+key-value pair returned from `pairs ∘ Functors.children`, combined with the previous `parent_key`
+by `combine`.
 
 ## Example
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, StableRNGs
 using LighthouseFlux, Lighthouse, Flux, Random
+using Statistics
 
 using CairoMakie
 CairoMakie.activate!(type="png")
@@ -64,6 +65,14 @@ end
             "train/update/gc_time_in_seconds_per_batch"
             "train/update/allocations_per_batch"
             "train/update/memory_in_mb_per_batch"
+            "train/gradients/chain/1/weight"
+            "train/gradients/chain/2/bias"
+            "train/gradients/chain/2/weight"
+            "train/gradients/chain/1/bias"
+            "train/weights/chain/1/weight"
+            "train/weights/chain/2/bias"
+            "train/weights/chain/2/weight"
+            "train/weights/chain/1/bias"
         ]
             @test length(logger.logged[key]) == length(train_batches) * limit
         end
@@ -97,6 +106,9 @@ end
                                     onehot=(x -> fill(x, length(classes))), onecold=sum)
         @test Lighthouse.onehot(classifier, 3) == fill(3, length(classes))
         @test Lighthouse.onecold(classifier, [0.31, 0.43, 0.13]) == 0.87
+
+        @test mean(classifier.model.chain[1].weight) ≈ logger.logged["train/weights/chain/1/weight"][end]
+        @test mean(classifier.model.chain[2].weight) ≈ logger.logged["train/weights/chain/2/weight"][end]
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,19 +36,18 @@ end
         logger = Lighthouse.LearnLogger(joinpath(tmpdir, "logs"), "test_run")
         limit = 4
         let counted = 0
-            upon_loss_decrease = Lighthouse.upon(logger,
-                                                 "test_set_prediction/mean_loss_per_epoch";
-                                                 condition=<, initial=Inf)
+            # Every epoch has the same number of batches, namely 100
+            upon_batch_index_same = Lighthouse.upon(logger,
+                                                 "train/batch_index";
+                                                 condition=(==), initial=100)
             callback = n -> begin
-                upon_loss_decrease() do _
+                upon_batch_index_same() do _
                     counted += n
                 end
             end
             elected = majority.((rng,), eachrow(votes), (1:length(classes),))
             Lighthouse.learn!(classifier, logger, () -> train_batches, () -> test_batches,
                               votes, elected; epoch_limit=limit, post_epoch_callback=callback)
-            # NOTE: the RNG chosen above just happens to allow this to work every time,
-            # since the loss happens to actually "improve" on the random data each epoch
             @test counted == sum(1:limit)
         end
         for key in [


### PR DESCRIPTION
~~Needs Lighthouse v0.14.6 and tests!~~

This PR uses the new `log_arrays!` Lighthouse logging interface function in order to log out weights and gradients during the course of training. The default for `log_arrays!` is to simply log the means, but that is up to the logger to implement based on what they can accomodate.

This uses a function `fforeach_keys` which I based on `Functors.fmap`, and discussed here: https://julialang.zulipchat.com/#narrow/stream/238249-machine-learning/topic/.60fmap.60.20with.20keys.3F.

Functors.jl provides an `@functor` macro which is the way Flux models declare their structure. This defines a `children` function to walk the model. We use that here in order to find the weights and gradients to log.

Closes https://github.com/beacon-biosignals/LighthouseFlux.jl/issues/33 incidentally